### PR TITLE
Made a more correct README and removed unused units.

### DIFF
--- a/GOLDParserCMP.pas
+++ b/GOLDParserCMP.pas
@@ -3,7 +3,7 @@ unit GOLDParserCMP;
 interface
 
 uses
-  Windows, Messages, SysUtils, Classes, GOLDParser, Token, Reduction, Rule, Symbol, stdCtrls;
+  SysUtils, Classes, GOLDParser, Token, Rule, Symbol;
 
 type
   TLexicalError = procedure(Sender: TObject) of Object;

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 goldparser-Lazarus
 ==================
 
-A component for work with Goldparser 5 from Lazarus
+A component for work with Gold Parser cgt grammar files from Lazarus.


### PR DESCRIPTION
- Unit GOLDParserCMP uses units Windows, Messages and StdCtrls while it doesn't need them.
  These units are removed.
- Additionally, you claim in the README that this engine works with GOLD Parser _5_. I have read the units and saw that it can only parse the old cgt files of version _1_. The README has been also corrected.

P.S: An engine which supports the version 5 egt grammar files can be found here: https://gitlab.com/teo-tsirpanis-718/gold-parser-lazarus
