### PR TITLE
A temporary fix for #1

### DIFF
--- a/SourceFeeder.pas
+++ b/SourceFeeder.pas
@@ -3,7 +3,7 @@ unit SourceFeeder;
 interface
 
 uses
-   Classes;
+   Classes, SysUtils;
 
 type
 
@@ -81,7 +81,7 @@ end;
 procedure TSourceFeeder.SetText(const Value: string);
 begin
   FStream.Size := 0;
-  FStream.WriteString(Value);
+  FStream.WriteString(AdjustLineBreaks(Value,tlbsCRLF));
   FStream.Position := 0;
 end;
 


### PR DESCRIPTION
It looks like that the engine has a problem in parsing source files ending in LF.
The source files are now converted to CRLF line endings before being loaded.
